### PR TITLE
Allow to use a .env file to override globals

### DIFF
--- a/kernel/utils/globals.js
+++ b/kernel/utils/globals.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 /**
  * @namespace FO
  * @desc FO global vars

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@uiTests": "tests/ui"
   },
   "dependencies": {
+    "dotenv": "^10.0.0",
     "module-alias": "^2.2.2",
     "playwright": "1.13.1"
   },


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the project! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | Allow to use a .env file to override globals
| Type?             |  improvement
| How to test?      | Have a .env file to add like FO_URL="http://localhost2/" and check that is the used URL (instead of localhost) to reach the BO page.
| Possible impacts? | Nothing here, just an extra dependency (basic one).


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
